### PR TITLE
Add dependency install instruction with brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,10 @@
  - sdl2_gfx
  - sdl2_image
  - sdl2_ttf
- - sdl2_mixer --with-flac --with-fluid-synth --with-libmikmod --with-libmodplug --with-libvorbis --with-smpeg2
+ - sdl2_mixer (with `smpeg2` or `libmad` for MP3 support)
+
+ On macOS, you can install dependencies via `brew`.
+ ```sh
+ brew install sdl2 sdl2_gfx sdl2_image sdl2_ttf
+ brew install sdl2_mixer --with-smpeg2
+ ```


### PR DESCRIPTION
Note that:
- MP3 support for sdl2_mixer can be provided by `libmad` on some platform. (e.g. Ubuntu)
- You only need `smpeg2` on macOS, unless you want to play other than WAV or MP3.